### PR TITLE
Fix path normalization

### DIFF
--- a/torrentool/torrent.py
+++ b/torrentool/torrent.py
@@ -324,7 +324,7 @@ class Torrent:
             if not file_size:
                 continue
 
-            target_files_.append((fpath, file_size, normpath(fpath.replace(src_path, '')).strip(sep).split(sep)))
+            target_files_.append((fpath, file_size, normpath(fpath.replace(f"{src_path}{sep}", '')).strip(sep).split(sep)))
             total_size += file_size
 
         return target_files_, total_size


### PR DESCRIPTION
Prevent corrupting filename in the case the path is contained in a file name

Ex. from current working dir:
```
DIR/
DIR/prefix_DIR_suffix.ext
```

`DIR/prefix_DIR_suffix.ext` would previously be normalize to `prefix__suffix.ext` since DIR is found in filename. It should instead be normalized to `prefix_DIR_suffix.ext`.