### PR TITLE
Allow install via pipx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     zip_safe=False,
 
     install_requires=[],
+    extras_require={'cli': ['click']},
     setup_requires=[] + PYTEST_RUNNER,
     tests_require=[
         'pytest',


### PR DESCRIPTION
I was going to use torrentool with an install via pipx. Installed but failed to run because `click` isn't specified as a dependency.

So I just added `extras_require={'cli': ['click']},` to `setup.py`, then installed via `pipx install torrentool[cli]`, and now it works.